### PR TITLE
[HUST CSE] [AI] Adjust the null pointer check and access order

### DIFF
--- a/X-CUBE-AI.7.0.0/Middlewares/ST/AI/Reloc/Src/ai_reloc_network.c
+++ b/X-CUBE-AI.7.0.0/Middlewares/ST/AI/Reloc/Src/ai_reloc_network.c
@@ -297,8 +297,6 @@ AI_DECLARE_STATIC
 int ai_reloc_rt_mcu_checking(const struct ai_reloc_bin_hdr *bin)
 {
 #if defined(AI_RELOC_RT_MCU_CHECKING) && AI_RELOC_RT_MCU_CHECKING == 1
-  const uint32_t flags = bin->hdr.flags;
-  const uint32_t cpuid = _GET_PART_NUMBER();
 
   if (!bin || (bin->hdr.magic != AI_RELOC_MAGIC) || (((uintptr_t)bin & 0x3) != 0)) {
 #if defined(APP_DEBUG) && APP_DEBUG == 1
@@ -306,6 +304,10 @@ int ai_reloc_rt_mcu_checking(const struct ai_reloc_bin_hdr *bin)
 #endif
       return -1;
   }
+
+  const uint32_t flags = bin->hdr.flags;
+  const uint32_t cpuid = _GET_PART_NUMBER();
+
 
   if (cpuid != AI_RELOC_RT_GET_CPUID(flags)) {
 #if defined(APP_DEBUG) && APP_DEBUG == 1

--- a/X-CUBE-AI.7.0.0/Middlewares/ST/AI/Validation/Src/pb_decode.c
+++ b/X-CUBE-AI.7.0.0/Middlewares/ST/AI/Validation/Src/pb_decode.c
@@ -659,14 +659,15 @@ static bool checkreturn decode_callback_field(pb_istream_t *stream, pb_wire_type
 {
     pb_callback_t *pCallback = (pb_callback_t*)iter->pData;
     
+    if (pCallback == NULL || pCallback->funcs.decode == NULL)
+        return pb_skip_field(stream, wire_type);
+        
 #ifdef PB_OLD_CALLBACK_STYLE
     void *arg = pCallback->arg;
 #else
     void **arg = &(pCallback->arg);
 #endif
     
-    if (pCallback == NULL || pCallback->funcs.decode == NULL)
-        return pb_skip_field(stream, wire_type);
     
     if (wire_type == PB_WT_STRING)
     {


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
在ai_reloc_network.c中ai_reloc_rt_mcu_checking函数中的指针变量bin访问在空指针判断之前进行，存在可能的空指针引用,进而引起程序异常退出。
```
int ai_reloc_rt_mcu_checking(const struct ai_reloc_bin_hdr *bin)
{
#if defined(AI_RELOC_RT_MCU_CHECKING) && AI_RELOC_RT_MCU_CHECKING == 1
  const uint32_t flags = bin->hdr.flags;
  const uint32_t cpuid = _GET_PART_NUMBER();

  if (!bin || (bin->hdr.magic != AI_RELOC_MAGIC) || (((uintptr_t)bin & 0x3) != 0)) {
#if defined(APP_DEBUG) && APP_DEBUG == 1
    printf("AI RELOC ERROR: Binary is invalid\r\n");
#endif
      return -1;
  }
```
在此给出文件的详细路径如下：
X-CUBE-AI.7.0.0/Middlewares/ST/AI/Reloc/Src/ai_reloc_network.c

在pb_decode.c中问题类似，checkreturn decode_callback_field函数中的指针变量pCallback访问在空指针判断之前进行，存在可能的空指针引用,进而引起程序异常退出。
```
static bool checkreturn decode_callback_field(pb_istream_t *stream, pb_wire_type_t wire_type, pb_field_iter_t *iter)
{
    pb_callback_t *pCallback = (pb_callback_t*)iter->pData;
    
#ifdef PB_OLD_CALLBACK_STYLE
    void *arg = pCallback->arg;
#else
    void **arg = &(pCallback->arg);
#endif
    
    if (pCallback == NULL || pCallback->funcs.decode == NULL)
        return pb_skip_field(stream, wire_type);
```
在此给出文件的详细路径如下：
X-CUBE-AI.7.0.0/Middlewares/ST/AI/Validation/Src/pb_decode.c

#### 你的解决方案是什么 (what is your solution)
修改顺序，使指针变量先进行空指针判断再进行访问

#### 在什么测试环境下测试通过 (what is the test environment)
ALL
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
